### PR TITLE
Fix `dvm ls` command description

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ right away.
 | dvm init [shell name]   | Print the path to the Deno runtime.               |
 | dvm install [version]   | Install a specific version of the Deno runtime.   |
 | dvm latest              | Install the latest version of the Deno runtime.   |
-| dvm ls                  | List all remote versions of the Deno runtime.     |
+| dvm ls                  | List installed versions of the Deno runtime.      |
 | dvm ls-remote           | List all remote versions of the Deno runtime.     |
 | dvm uninstall [version] | Uninstall a specific version of the Deno runtime. |
 | dvm use [version]       | Set the Deno runtime version.                     |


### PR DESCRIPTION
Now it matches the one given to cmdliner.